### PR TITLE
server_address missing line break

### DIFF
--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -2,7 +2,7 @@
 log_facility=daemon
 pid_file=<%= scope.lookupvar('nrpe::pid_file') %>
 server_port=<%= scope.lookupvar('nrpe::port') %>
-<% if scope.lookupvar('nrpe::server_address') != '' -%>server_address=<%= scope.lookupvar('nrpe::server_address') %><% end -%>
+<% if scope.lookupvar('nrpe::server_address') != '' -%>server_address=<%= scope.lookupvar('nrpe::server_address') %><% end %>
 nrpe_user=<%= scope.lookupvar('nrpe::process_user') %>
 nrpe_group=<%= scope.lookupvar('nrpe::process_user') %>
 allowed_hosts=<% if allowed_hosts.class == Array then %><%= allowed_hosts.flatten.join(',') %><% else %><%= allowed_hosts %><% end %>


### PR DESCRIPTION
I have provided a server_address to nrpe and ended up having a line like server_address=x.x.x.xnrpe_user=nagios without a line break. 
For me this change fixed the problem. 

Thanks four your great modules and presentations!
