### PR TITLE
Add proper $pid_file location for Debian Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,7 @@ class nrpe::params {
   }
 
   $pid_file = $::operatingsystem ? {
-    /(?i:Ubuntu|Mint)/                                  => '/var/run/nagios/nrpe.pid',
+    /(?i:Debian|Ubuntu|Mint)/                           => '/var/run/nagios/nrpe.pid',
     /(?i:Centos|RedHat|Scientific|Fedora|Amazon|Linux)/ => '/var/run/nrpe/nrpe.pid',
     default                                             => '/etc/run/nrpe.pid',
   }


### PR DESCRIPTION
The parameter `pid_file` was missing for Debian Linux and was pointing to `/etc/run/nrpe.pid` instead of the correct `/var/run/nagios/nrpe.pid`.
