### PR TITLE
Renamed 'check_all_disks' to 'check_all_disks_param', added sysstat support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -248,6 +248,11 @@
 # [*version*]
 #   The version of nrpe package to be installed
 #
+# [*enable_sysstat*]
+#   Enable various services through sysstat/sar.
+#
+# [*sysstat_package*]
+#   The package to install when $enable_sysstat was set to true
 #
 # == Examples
 #
@@ -314,11 +319,14 @@ class nrpe (
   $log_file            = params_lookup( 'log_file' ),
   $port                = params_lookup( 'port' ),
   $protocol            = params_lookup( 'protocol' ),
-  $version             = params_lookup( 'version' )
+  $version             = params_lookup( 'version' ),
+  $enable_sysstat      = params_lookup( 'enable_sysstat' ),
+  $sysstat_package     = params_lookup( 'sysstat_package')
   ) inherits nrpe::params {
 
   $bool_use_ssl=any2bool($use_ssl)
   $bool_source_dir_purge=any2bool($source_dir_purge)
+  $bool_enable_sysstat=any2bool($enable_sysstat)
   $bool_service_autorestart=any2bool($service_autorestart)
   $bool_absent=any2bool($absent)
   $bool_disable=any2bool($disable)
@@ -468,6 +476,10 @@ class nrpe (
     if ! defined(Package[$nrpe::pluginspackage]) {
       package { $nrpe::pluginspackage : ensure => present }
     }
+  }
+
+  if $bool_enable_sysstat == true {
+    include nrpe::plugin::check_sar_perf
   }
 
   ### Include custom class if $my_class is set

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -133,6 +133,9 @@ class nrpe::params {
     default => '/var/log/messages',
   }
 
+  $enable_sysstat  = false
+  $sysstat_package = 'sysstat'
+
   $port = '5666'
   $protocol = 'tcp'
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -2,9 +2,27 @@
 #
 # Adds or configures a Nrpe plugin
 #
-# Usage:
+# == Parameters
 #
+# Module Specific parameters
+#
+# [*source*]
+#   The source of the content to use as plugin.
+#   Can be omitted if a template path is specified instead.
+#
+# [*source_prefix*]
+#   Prefix of the source. Defaults to puppet:///
+#
+# [*template*]
+#   The template to use for the plugin contents.
+#
+# [*enable*]
+#   To enable, or not to enable - that's the question.
+#
+#
+# == Examples#
 # Provide a custom plugin:
+#
 # nrpe::plugin { 'check_redis':
 #   source => 'example42/nrpe/redis',
 # }
@@ -12,11 +30,26 @@
 
 define nrpe::plugin (
   $source = '',
-  $enable = true ) {
+  $source_prefix = 'puppet:///',
+  $template = undef,
+  $enable = true,
+) {
 
   $ensure = bool2ensure($enable)
 
-  if $source {
+  if ($source == undef or $source == '') {
+    $source_path = undef
+  } else {
+    $source_path = "${source_prefix}${source}"
+  }
+
+  if ($template != undef) {
+    $content = template($template)
+  } else {
+    $content = undef
+  }
+
+  if $source_path or $content {
     file { "Nrpe_plugin_${name}":
       path    => "${nrpe::pluginsdir}/${name}",
       owner   => root,
@@ -25,10 +58,9 @@ define nrpe::plugin (
       ensure  => $ensure,
       require => Package['nrpe'],
       notify  => Service['nrpe'],
-      source  => "puppet:///$source",
+      source  => $source_path,
+      content => $content
     }
   }
 
-
 }
-

--- a/manifests/plugin/check_sar_perf.pp
+++ b/manifests/plugin/check_sar_perf.pp
@@ -1,0 +1,24 @@
+class nrpe::plugin::check_sar_perf {
+
+  if (! defined( Package[$nrpe::sysstat_package] )) {
+    package { $nrpe::sysstat_package: }
+  }
+
+  nrpe::plugin { 'check_sar_perf':
+    template => 'nrpe/plugin/check_sar_perf.py.erb'
+  }
+
+  file { 'nrpe_plugin_check_sar_perf_config':
+    ensure  => $nrpe::manage_file,
+    path    => "${nrpe::config_dir}/check_sar_perf.cfg",
+    mode    => $nrpe::config_file_mode,
+    owner   => $nrpe::config_file_owner,
+    group   => $nrpe::config_file_group,
+    require => Package['nrpe'],
+    notify  => $nrpe::manage_service_autorestart,
+    content => template('nrpe/plugin/check_sar_perf.cfg.erb'),
+    replace => $nrpe::manage_file_replace,
+    audit   => $nrpe::manage_audit,
+  }
+
+}

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -25,7 +25,7 @@ command[check_url]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_http -I "$AR
 command[check_url_auth]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_http -I "$ARG1$" -p "$ARG2$" -u "$ARG3$" -r "$ARG4$" -a "$ARG5$" -A "$ARG6$"-H "$ARG7"
 command[check_swap]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_swap -w 40% -c 20%
 command[check_mailq]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_mailq -w 1 -c 5
-command[check_all_disks]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_disk -w 20% -c 10% -L -X tmpfs
+command[check_all_disks_param]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_disk -w 20% -c 10% -L -X tmpfs
 command[check_users]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_users -w 5 -c 10
 command[check_load]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_load -w 15,10,5 -c 30,25,20
 command[check_zombie_procs]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_procs -w 5 -c 10 -s Z

--- a/templates/plugin/check_sar_perf.cfg.erb
+++ b/templates/plugin/check_sar_perf.cfg.erb
@@ -1,0 +1,12 @@
+# File managed by Puppet
+
+command[check_sar_pagestat]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf pagestat
+command[check_sar_cpu]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf cpu
+command[check_sar_memory_util]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf memory_util
+command[check_sar_memory_stat]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf memory_stat
+command[check_sar_io_transfer]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf io_transfer
+command[check_sar_queueln_load]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf queueln_load
+command[check_sar_swap_util]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf swap_util
+command[check_sar_swap_stat]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf swap_stat
+command[check_sar_task]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf task
+command[check_sar_kernel]=<%= scope.lookupvar('nrpe::pluginsdir') %>/check_sar_perf kernel

--- a/templates/plugin/check_sar_perf.py.erb
+++ b/templates/plugin/check_sar_perf.py.erb
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+#
+# FILE MANAGED BY PUPPET
+#
+# File originally derived from:
+# https://github.com/dnsmichi/icinga-plugins/blob/master/scripts/check_sar_perf.py
+#
+# Copyright (c) 2010, Nick Anderson <nick@cmdln.org>
+# All rights reserved.
+#
+# Modified 2012-07-11 by Michael Friedrich <michael.friedrich@univie.ac.at>
+#
+# sar uses the locale time in order to format the output
+# previously, the plugin matched only
+#   04:13:43 PM  pgpgin/s pgpgout/s   fault/s  majflt/s  pgfree/s pgscank/s pgscand/s pgsteal/s    %vmeff
+#   04:13:44 PM  17664.00  12672.00     52.00      0.00  11394.00      0.00      0.00      0.00      0.00
+# which does not work with the default format
+#   16:13:16     pgpgin/s pgpgout/s   fault/s  majflt/s  pgfree/s pgscank/s pgscand/s pgsteal/s    %vmeff
+#   16:13:17     13952.00  73640.00     36.00      0.00  10970.00      0.00      0.00      0.00      0.00
+# since all systems should share the same, the command is instrumented using POSIX
+# time formatting, which makes it work on both ends again.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import re
+from subprocess import *
+
+
+os.environ['PATH'] = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin'
+#Nagios return code level
+# 0 - OK       - The plugin was able to check the service and it appeared to be functioning properly 
+# 1 - WARNING  - The plugin was able to check the service, but it appeared to be above some "warning" 
+#                threshold or did not appear to be working properly
+# 2 - CRITICAL - The plugin detected that either the service was not running or it was above some "critical" threshold
+# 3 - UNKNOWN  - Invalid command line arguments were supplied to the plugin or low-level failures 
+#                internal to the plugin (such as unable to fork, or open a tcp socket) that prevent 
+#                it from performing the specified operation. Higher-level errors (such as name 
+#                resolution errors, socket timeouts, etc) are outside of the control of plugins and 
+#                should generally NOT be reported as UNKNOWN states. 
+ERR_OK = 0
+ERR_WARN = 1
+ERR_CRIT = 2
+ERR_UNKN = 3
+
+class SarNRPE:
+    '''Call sar and parse statistics returning in NRPE format'''
+    def __init__(self, command, device=None):
+	# tell sar to use the posix time formatting to stay safe
+	command = 'LC_TIME="POSIX" '+command
+        sar=Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+        (sout,serr) = sar.communicate()
+	### debug
+        #print sout
+        if device == None:
+            (columns, data) = self.SortOutput(sout)
+        else:
+            (columns, data) = self.SortCombinedOutput(sout, device)
+
+        self.Formatter(columns, data)
+
+    def SortOutput(self, sarout):
+        '''Sort output of sar command, return column and data tuple'''
+        data = sarout.split('\n')[-2].split()
+        # remove 'Average:'
+        data.pop(0)
+	### debug
+	#print data
+        columns = sarout.split('\n')[-4].split()
+	# Remove Timestamp - 16:13:16
+        columns.pop(0)
+        
+        # The original script only popped one column. At least Ubuntu
+        # 12.04 requires 2 columns to be popped.
+        columns.pop(0)
+	# timestamp is posix, so no AM or PM
+	### debug
+	#print columns
+        return (columns, data)
+
+    def SortCombinedOutput(self, sarout, device):
+        '''Sorts column and data output from combined report and displays
+        only relevant information returns column and data tuple'''
+        find_columns = True
+        mycolumns = []
+        mydata = []
+        # Find the column titles
+        search = re.compile('^Average:')
+        for line in sarout.split('\n'):
+            if search.match(line):
+                if find_columns:
+                    mycolumns.append(line)
+                    find_columns = False
+                else:
+                    mydata.append(line)
+        # Find the only Average line with the device we are looking for
+        search = re.compile('^Average:\s.*%s\s.*' %device)
+        for line in mydata[:]:
+            if not search.match(line):
+                mydata.remove(line)
+        mycolumns = mycolumns[0].split()
+        mydata = mydata[0].split()
+        mycolumns.pop(0)
+        mydata.pop(0)
+        return (mycolumns,mydata)
+
+    def Formatter(self, columns, data):
+        '''Construct nrpe format performance data'''
+        search = re.compile('^[a-zA-Z]+$')
+        self.stats = []
+        # Create dictionary
+        for i in range(len(columns)):
+	    # debug	
+	    #print columns[i], ": ", data[i]	
+            # Remove first column if data contains only letters
+            if i != 0 or not search.match(data[i]):
+                # Remove characters that cause issues (%/)
+                badchars=['%','/']
+                columns[i] = ''.join(j for j in columns[i] if j not in badchars)
+                # debug
+                # print "Appended data: ", data[i]
+                string = "%s=%s" %(columns[i].strip('%/'), data[i].strip())
+		### debug
+		#print string
+                self.stats.append(string)
+		### debug
+
+def CheckBin(program):
+    '''Ensure the program exists in the PATH'''
+    for path in os.environ.get('PATH', '').split(':'):
+        if os.path.exists(os.path.join(path, program)) and \
+           not os.path.isdir(os.path.join(path, program)):
+               return os.path.join(path, program)
+               #return True
+    return False
+
+
+def Main(args):
+    # Ensure a profile (aka myOpts) is selected
+    if not len(args) > 1:
+        print 'ERROR: no profile selected'
+        sys.exit(ERR_UNKN)
+    if not CheckBin('sar'):
+        print 'ERROR: sar not found on PATH (%s), install sysstat' %os.environ['PATH']
+        sys.exit(ERR_CRIT)
+  
+    # Profiles may need to be modified for different versions of the sysstat package
+    # This would be a good candidate for a config file 
+    myOpts = {}
+    myOpts['pagestat'] = 'sar -B 1 1'
+    myOpts['cpu'] = 'sar 1 1'
+    myOpts['memory_util'] = 'sar -r 1 1'
+    myOpts['memory_stat'] = 'sar -R 1 1'
+    myOpts['io_transfer'] = 'sar -b 1 1'
+    myOpts['queueln_load'] = 'sar -q 1 1'
+    myOpts['swap_util'] = 'sar -S 1 1'
+    myOpts['swap_stat'] = 'sar -W 1 1'
+    myOpts['task'] = 'sar -w 1 1'
+    myOpts['kernel'] = 'sar -v 1 1'
+    myOpts['disk'] = 'sar -d -p 1 1'
+    
+    # If profile uses combined output you must pick one device to report on ie sda for disk
+    if args[1] in myOpts:
+        if args[1] == 'disk':
+            if len(args) > 2:
+                sar = SarNRPE(myOpts[args[1]],args[2])
+            else:
+                print 'ERROR: no device specified'
+                sys.exit(ERR_UNKN)
+        else:
+            sar = SarNRPE(myOpts[args[1]])
+    else:
+        print 'ERROR: option not defined'
+        sys.exit(ERR_UNKN)
+
+    # Output in NRPE format
+    print 'sar OK |', ' '.join(sar.stats)
+
+    sys.exit(ERR_OK)
+
+if __name__ == '__main__':
+    Main(sys.argv)
+


### PR DESCRIPTION
While integrating with Icinga I got an error that the command 'check_all_disks_param' was unknown. I found a discrepancy between how it's used in NRPE and Icinga. Because it's used multiple times in Icinga, I figured the intention was to call it check_all_disks_param. Therefore I updated it in this module.

Furthermore, the folks behind Icinga suggest using sysstat for monitoring certain resources (here: https://wiki.icinga.org/display/howtos/Monitoring+the+Icinga+Host ). The python script I used is one maintained by the maintainer of Icinga @dnsmichi .
