### PR TITLE
Fix owner, group y mode when copied entire nrpe.dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -484,6 +484,9 @@ class nrpe (
   file { 'nrpe.dir':
     ensure  => directory,
     path    => $nrpe::config_dir,
+    mode    => $nrpe::config_file_mode,
+    owner   => $nrpe::config_file_owner,
+    group   => $nrpe::config_file_group,
     require => Package['nrpe'],
     notify  => $nrpe::manage_service_autorestart,
     source  => $nrpe::manage_dir_source,


### PR DESCRIPTION
I have added code to ensure owner, group and mode of files copied with $source_dir parameters. Without this, files are copied with samen owner, group and mode that they are stored in the source.
