### PR TITLE
Parsing error with future parser

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -532,7 +532,7 @@ class nrpe (
     }
   }
 
-  if $pluginsdir_source {
+  if $pluginsdir_source and $pluginsdir_source != '' {
     file { 'Nrpe_plugins':
       ensure  => directory,
       path    => $nrpe::pluginsdir,


### PR DESCRIPTION
parser = future produces this error

Parameter source failed on File[Nrpe_plugins]: Cannot use relative URLs ''

You fixed this already in other modules.

Please greate a new version for / on puppetlabs.
